### PR TITLE
changed my_addr SocketAddress to 0.0.0.0 instead of using Poco interface to fix bug on OSX

### DIFF
--- a/src/ofxNatNet.cpp
+++ b/src/ofxNatNet.cpp
@@ -123,8 +123,9 @@ struct ofxNatNet::InternalThread : public ofThread
 			{
 				Poco::Net::SocketAddress addr(Poco::Net::IPAddress::wildcard(),
 											  data_port);
-				
-				try
+				/*
+				// redundant see line 158
+                try
 				{
 					interface = Poco::Net::NetworkInterface::forAddress(Poco::Net::IPAddress(interface_name));
 				}
@@ -133,6 +134,7 @@ struct ofxNatNet::InternalThread : public ofThread
 					interface = Poco::Net::NetworkInterface::forName(
 						interface_name, Poco::Net::NetworkInterface::IPv4_ONLY);
 				}
+                */
 
 				data_socket.bind(addr, true);
 				data_socket.joinGroup(Poco::Net::IPAddress(multicast_group),
@@ -153,7 +155,8 @@ struct ofxNatNet::InternalThread : public ofThread
 			}
 
 			{
-				Poco::Net::SocketAddress my_addr("0.0.0.0", 0);
+				// We now use directly 0.0.0.0 instead of interface.address() since this returns an ipv6 address on OSX with of 0.10.0
+                Poco::Net::SocketAddress my_addr("0.0.0.0", 0);
 				command_socket.bind(my_addr, true);
 				command_socket.setReceiveBufferSize(0x100000);
 				command_socket.setBroadcast(true);

--- a/src/ofxNatNet.cpp
+++ b/src/ofxNatNet.cpp
@@ -153,7 +153,7 @@ struct ofxNatNet::InternalThread : public ofThread
 			}
 
 			{
-				Poco::Net::SocketAddress my_addr(interface.address(), 0);
+				Poco::Net::SocketAddress my_addr("0.0.0.0", 0);
 				command_socket.bind(my_addr, true);
 				command_socket.setReceiveBufferSize(0x100000);
 				command_socket.setBroadcast(true);

--- a/src/ofxNatNet.cpp
+++ b/src/ofxNatNet.cpp
@@ -117,9 +117,7 @@ struct ofxNatNet::InternalThread : public ofThread
 			{
 				Poco::Net::SocketAddress addr(Poco::Net::IPAddress::wildcard(),
 											  data_port);
-				/*
-				// redundant see line 158
-                try
+				                try
 				{
 					interface = Poco::Net::NetworkInterface::forAddress(Poco::Net::IPAddress(interface_name));
 				}
@@ -128,7 +126,7 @@ struct ofxNatNet::InternalThread : public ofThread
 					interface = Poco::Net::NetworkInterface::forName(
 						interface_name, Poco::Net::NetworkInterface::IPv4_ONLY);
 				}
-                */
+                
 
 				data_socket.bind(addr, true);
 				data_socket.joinGroup(Poco::Net::IPAddress(multicast_group),
@@ -149,8 +147,14 @@ struct ofxNatNet::InternalThread : public ofThread
 			}
 
 			{
-				// We now use directly 0.0.0.0 instead of interface.address() since this returns an ipv6 address on OSX with of 0.10.0
+
+                
+                
+#ifndef TARGET_OS_X      //on OSX interface.address() returns an ipv6 address 
                 Poco::Net::SocketAddress my_addr("0.0.0.0", 0);
+#else
+                Poco::Net::SocketAddress my_addr(interface.address(), 0);
+#endif
 				command_socket.bind(my_addr, true);
 				command_socket.setReceiveBufferSize(0x100000);
 				command_socket.setBroadcast(true);


### PR DESCRIPTION
On osx Poco Interface returns ipv6 addrs instead of ipv4 ip using 0.0.0.0 bypasses this.